### PR TITLE
Fix css about weird indented h1 tag

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -135,7 +135,6 @@ h1,h2,h3,h4,h5,h6{
 
 h1 {
     font-size: 2.2rem;
-    margin: 0px;
 }
 .post-content h1 {
     border-bottom: 1px solid $main-color-1;


### PR DESCRIPTION
h1 태그가 이상하게 인덴트되는 문제를 해결합니다.

https://github.com/johngrib/johngrib.github.io/discussions/351#discussioncomment-8741613

![image](https://github.com/honggaruy/honggaruy.github.io/assets/1855714/d9a01fbb-e42c-4826-ac7d-a70aced65ded)
